### PR TITLE
missing zlib1g-dev package causes to fail installing sentry

### DIFF
--- a/tasks/sentry.yml
+++ b/tasks/sentry.yml
@@ -13,7 +13,7 @@
 
 - name: Install Dependencies
   apt: name={{item}}
-  with_items: [libxml2-dev, libxslt1-dev]
+  with_items: [libxml2-dev, libxslt1-dev, zlib1g-dev]
 
 - name: Install Sentry
   pip: name=sentry executable={{sentry_home}}/env/bin/pip version={{sentry_version}}


### PR DESCRIPTION
The Error:

```sh
TASK: [roles/Stouts.sentry | Install Sentry] *********************
...stripped...
x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions  
-Wl,-Bsymbolic-functions -Wl,-z,relro -fno-strict-aliasing -DNDEBUG -g  
-fwrapv -O2 -Wall -Wstrict-prototypes -D_FORTIFY_SOURCE=2 -g   
-fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security  
build/temp.linux-x86_64-2.7/src/lxml/lxml.etree.o -lxslt -lexslt -lxml2 -lz  
-lm -o build/lib.linux-x86_64-2.7/lxml/etree.so

    /usr/bin/ld: cannot find -lz

    collect2: error: ld returned 1 exit status
...stripped...
```

Environment:
- Ubuntu Trusty 14.04 running in aws (ami-9a380b87)
- Stouts.foundation 1.0.5

Fixing this by installing zlib1g-dev.
