### PR TITLE
Bump to latest Sentry, HTTPS support

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,3 +3,4 @@ Contributors:
 * Kirill Klenov (http://klen.github.io/)
 * Evgeny Gorchakov (https://github.com/evgorchakov)
 * Mantas Radzevičius (https://github.com/mn7z)
+* Mikko Ohtamaa (http://opensourcehacker.com/)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,9 @@ sentry_https_url: no
 sentry_secret_key: 1LsmGR1DIyCJ5n2bRG5IVOFHdzEPkTKlW0RzxZVe9S0vc
 sentry_extensions: []                                     # List of sentry-extensions
 
+sentry_virtualenv_command: virtualenv2.7                  # In the case of multiple Python installations
+                                                          # Pick one for Sentry using specific virtualenv command
+
 sentry_ssl_certificate:                                   # SSL certificate file - also turns on HTTPS on Nginx
 sentry_ssl_certificate_key:                               # Key file for SSL cert
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 
 sentry_enabled: yes                                       # Enable the role
 sentry_version: 7.1.4
+sentry_version: 7.4.3
 sentry_home: /usr/lib/sentry                              # Deploy sentry to the folder
 sentry_user: sentry                                       # Run as user
 sentry_hostname: "{{inventory_hostname}}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,8 @@ sentry_https_url: no
 sentry_secret_key: 1LsmGR1DIyCJ5n2bRG5IVOFHdzEPkTKlW0RzxZVe9S0vc
 sentry_extensions: []                                     # List of sentry-extensions
 
-sentry_virtualenv_command: virtualenv2.7                  # In the case of multiple Python installations
+# Python configuration
+sentry_python: python2.7                                  # In the case of multiple Python  installations
                                                           # Pick one for Sentry using specific virtualenv command
 
 sentry_ssl_certificate:                                   # SSL certificate file - also turns on HTTPS on Nginx

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,11 @@ sentry_https_url: no
 sentry_secret_key: 1LsmGR1DIyCJ5n2bRG5IVOFHdzEPkTKlW0RzxZVe9S0vc
 sentry_extensions: []                                     # List of sentry-extensions
 
+# Python settings
+sentry_python: /usr/bin/python                            # Override this to python3.4 if you want to use
+                                                          # different Python version
+
+
 # Initial data
 sentry_admin_username: admin                              # Creates admin user with credentials, set blank for skip
 sentry_admin_email: admin@{{sentry_hostname}}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 
 sentry_enabled: yes                                       # Enable the role
-sentry_version: 7.1.4
 sentry_version: 7.4.3
 sentry_home: /usr/lib/sentry                              # Deploy sentry to the folder
 sentry_user: sentry                                       # Run as user
@@ -11,10 +10,8 @@ sentry_https_url: no
 sentry_secret_key: 1LsmGR1DIyCJ5n2bRG5IVOFHdzEPkTKlW0RzxZVe9S0vc
 sentry_extensions: []                                     # List of sentry-extensions
 
-# Python settings
-sentry_python: /usr/bin/python                            # Override this to python3.4 if you want to use
-                                                          # different Python version
-
+sentry_ssl_certificate:                                   # SSL certificate file - also turns on HTTPS on Nginx
+sentry_ssl_certificate_key:                               # Key file for SSL cert
 
 # Initial data
 sentry_admin_username: admin                              # Creates admin user with credentials, set blank for skip

--- a/tasks/sentry.yml
+++ b/tasks/sentry.yml
@@ -11,10 +11,16 @@
   with_items: [libxml2-dev, libxslt1-dev, zlib1g-dev, libffi-dev]
 
 # Try to create virtualenv only if it doesn't exist.
-# This way we can rerun the playbook without errors.
-# true && hack at the start of the line, otherwise one gets YAML syntax errors
+# This way we can re-run the playbook without errors.
+- name: Check existince of created virtualenv
+  stat: path={{sentry_home}}/env
+  register: sentry_has_virtualenv
+  sudo: yes
+  sudo_user: "{{sentry_user}}"
+
 - name: Create virtualenv for Sentry using chosen Python
-  shell: true && [[ ! -d {{sentry_home}}/env ]] || virtualenv --python={{sentry_python}} {{sentry_home}}/env
+  when: sentry_has_virtualenv.stat.exists == False
+  shell: virtualenv --python={{sentry_python}} {{sentry_home}}/env
   sudo: yes
   sudo_user: "{{sentry_user}}"
 

--- a/tasks/sentry.yml
+++ b/tasks/sentry.yml
@@ -11,7 +11,7 @@
   with_items: [libxml2-dev, libxslt1-dev, zlib1g-dev,libffi-dev, python-virtualenv, python-dev]
 
 - name: Install Sentry
-  pip: name=sentry executable={{sentry_home}}/env/bin/pip version={{sentry_version}} virtualenv="{{sentry_home}}"/env
+  pip: name=sentry executable={{sentry_home}}/env/bin/pip version={{sentry_version}} virtualenv_command="{{sentry_virtualenv_command}}" virtualenv="{{sentry_home}}"/env
   sudo: yes
   sudo_user: "{{sentry_user}}"
 

--- a/tasks/sentry.yml
+++ b/tasks/sentry.yml
@@ -12,7 +12,7 @@
 
 # Try to create virtualenv only if it doesn't exist.
 # This way we can re-run the playbook without errors.
-- name: Check existince of created virtualenv
+- name: Check existince of Sentry virtualenv
   stat: path={{sentry_home}}/env
   register: sentry_has_virtualenv
   sudo: yes

--- a/tasks/sentry.yml
+++ b/tasks/sentry.yml
@@ -8,10 +8,18 @@
 
 - name: Install Dependencies
   apt: name={{item}}
-  with_items: [libxml2-dev, libxslt1-dev, zlib1g-dev,libffi-dev, python-virtualenv, python-dev]
+  with_items: [libxml2-dev, libxslt1-dev, zlib1g-dev, libffi-dev]
+
+# Try to create virtualenv only if it doesn't exist.
+# This way we can rerun the playbook without errors.
+# true && hack at the start of the line, otherwise one gets YAML syntax errors
+- name: Create virtualenv for Sentry using chosen Python
+  shell: true && [[ ! -d {{sentry_home}}/env ]] || virtualenv --python={{sentry_python}} {{sentry_home}}/env
+  sudo: yes
+  sudo_user: "{{sentry_user}}"
 
 - name: Install Sentry
-  pip: name=sentry executable={{sentry_home}}/env/bin/pip version={{sentry_version}} virtualenv_command="{{sentry_virtualenv_command}}" virtualenv="{{sentry_home}}"/env
+  pip: name=sentry executable={{sentry_home}}/env/bin/pip version={{sentry_version}}  virtualenv="{{sentry_home}}"/env
   sudo: yes
   sudo_user: "{{sentry_user}}"
 

--- a/tasks/sentry.yml
+++ b/tasks/sentry.yml
@@ -6,17 +6,12 @@
 - name: Ensure sentry directories exists
   file: state=directory path={{sentry_home}} owner={{sentry_user}}
 
-- name: Setup virtualenv
-  shell: virtualenv {{sentry_home}}/env --python=python creates={{sentry_home}}/env/bin/pip
-  sudo: yes
-  sudo_user: "{{sentry_user}}"
-
 - name: Install Dependencies
   apt: name={{item}}
-  with_items: [libxml2-dev, libxslt1-dev, zlib1g-dev]
+  with_items: [libxml2-dev, libxslt1-dev, zlib1g-dev,libffi-dev, python-virtualenv, python-dev]
 
 - name: Install Sentry
-  pip: name=sentry executable={{sentry_home}}/env/bin/pip version={{sentry_version}}
+  pip: name=sentry executable={{sentry_home}}/env/bin/pip version={{sentry_version}} virtualenv="{{sentry_home}}"/env
   sudo: yes
   sudo_user: "{{sentry_user}}"
 

--- a/templates/config.py.j2
+++ b/templates/config.py.j2
@@ -23,6 +23,8 @@ DATABASES = {
 }
 
 {% if sentry_cache_backend and sentry_cache_location %}
+SENTRY_CACHE = 'sentry.cache.django.DjangoCache'
+
 CACHES = {
     'default': {
         'BACKEND': '{{sentry_cache_backend}}',

--- a/templates/config.py.j2
+++ b/templates/config.py.j2
@@ -22,9 +22,9 @@ DATABASES = {
     }
 }
 
-{% if sentry_cache_backend and sentry_cache_location %}
 SENTRY_CACHE = 'sentry.cache.django.DjangoCache'
 
+{% if sentry_cache_backend and sentry_cache_location %}
 CACHES = {
     'default': {
         'BACKEND': '{{sentry_cache_backend}}',

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -10,6 +10,21 @@ server {
     listen     {{ sentry_port|default(80) }};
     server_name {{sentry_hostname}};
 
+    {% if sentry_ssl_certificate %}
+        ssl on;
+        ssl_certificate {{ sentry_ssl_certificate }};
+        ssl_certificate_key {{ sentry_ssl_certificate_key }};
+
+        # https://wiki.mozilla.org/Security/Server_Side_TLS
+        # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
+        # ssl_dhparam /path/to/dhparam.pem;
+        ssl_session_timeout 5m;
+        ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-ECDSA-RC4-SHA:AES128:AES256:RC4-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK';
+        ssl_prefer_server_ciphers on;
+        ssl_session_cache shared:SSL:50m;
+    {% endif %}
+
     access_log {{sentry_access_log}};
     error_log {{sentry_error_log}};
 


### PR DESCRIPTION
This pull request adds support for HTTPS Nginx configuration.

I also updated Sentry to the latest version, added some missing dependencies.

I had to change how Sentry virtualenv is created a bit, as there was a potential conflict for systems where one had multiple Python interpreters installed. Thus, one can explicity say which Python to use. 

I have a Playbook demoing HTTPS here: https://github.com/miohtama/LibertyMusicStore/tree/master/ansible - if it looks good I can copy instructions to Stouts.sentry to separate README.HTTPS.md and update README.md with new variables?

Cheers,
Mikko

