### PR TITLE
Fix: sentry_port is int

### DIFF
--- a/templates/config.py.j2
+++ b/templates/config.py.j2
@@ -9,7 +9,7 @@ CONF_ROOT = os.path.dirname(__file__)
 STATIC_ROOT = '{{sentry_home}}/_static'
 
 SECRET_KEY = '{{sentry_secret_key}}'
-SENTRY_URL_PREFIX = '{{ "https" if sentry_https_url else "http" }}://{{sentry_hostname}}{% if sentry_port != '80' %}:{{sentry_port}}{% endif %}'
+SENTRY_URL_PREFIX = '{{ "https" if sentry_https_url else "http" }}://{{sentry_hostname}}{% if sentry_port != 80 %}:{{sentry_port}}{% endif %}'
 
 DATABASES = {
     'default': {


### PR DESCRIPTION
Otherwise, it will has `:80` all the time.