### PR TITLE
Use noinput to stop prompts in scripts

### DIFF
--- a/tasks/sentry.yml
+++ b/tasks/sentry.yml
@@ -68,7 +68,7 @@
 - file: state=directory path={{sentry_home}} owner={{sentry_user}} recurse=yes
 
 - name: Upgrade sentry
-  shell: "{{sentry_home}}/sentry --config={{sentry_home}}/config.py upgrade"
+  shell: "{{sentry_home}}/sentry --config={{sentry_home}}/config.py upgrade --noinput"
   when: config.changed
   sudo: yes
   sudo_user: "{{sentry_user}}"


### PR DESCRIPTION
Otherwise, the upgrade command could prompt for input. In a script, it
will never get that input and it will seem that the script has become
stuck.