### PR TITLE
Add Chart for SENTRY

### DIFF
--- a/templates/config.py.j2
+++ b/templates/config.py.j2
@@ -49,6 +49,7 @@ SENTRY_REDIS_OPTIONS = {
         }
     }
 }
+SENTRY_TSDB = 'sentry.tsdb.redis.RedisTSDB'
 {% endif %}
 
 # If you're using a reverse proxy, you should enable the X-Forwarded-Proto


### PR DESCRIPTION
Event Chart won't work without this configuration.

This one:

![image](https://cloud.githubusercontent.com/assets/290496/10687209/d709bba6-799d-11e5-8635-773bb7ecb755.png)
