### PR TITLE
Add nginx body size

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,6 +85,7 @@ sentry_access_log: /var/log/sentry-access.log
 sentry_error_log: /var/log/sentry-error.log
 
 sentry_nginx_timeout: 15s
+sentry_nginx_body_size: 150k
 
 # The following parameters are for toggling dependencies
 redis_enabled: yes

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -42,8 +42,8 @@ server {
     resolver_timeout {{sentry_nginx_timeout}};
     client_body_timeout {{sentry_nginx_timeout}};
 
-    client_max_body_size 150k;
-    client_body_buffer_size 150k;
+    client_max_body_size {{sentry_nginx_body_size}};
+    client_body_buffer_size {{sentry_nginx_body_size}};
 
     location / {
       proxy_pass        http://{{sentry_web_host}}:{{sentry_web_port}};


### PR DESCRIPTION
Changing max body size is required. Sentry has a release API, we need to upload
source map files to this release API. Source map files can be 1M above.
